### PR TITLE
Removes antimagic from holymelons

### DIFF
--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -57,7 +57,3 @@
 	dried_type = null
 	wine_power = 70 //Water to wine, baby.
 	wine_flavor = "divinity"
-
-/obj/item/reagent_containers/food/snacks/grown/holymelon/Initialize()
-	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE) //deliver us from evil o melon god


### PR DESCRIPTION
## About The Pull Request

Deletes antimagic component from holymelons

## Why It's Good For The Game

Holymelons were becoming overly centralizing to the antags that they countered with pocket antimagic, to the point botanists were growing it every single round just to metagame said antagonists.

Holymelons still contain holy water and thus are still a viable way to deal with cult without a chaplain.

## Changelog
:cl: Yakumo Chen
balance: removed antimagic component from holymelons
/:cl:
